### PR TITLE
Add `LOOM_SPEC_VERSION` attribute to exported files

### DIFF
--- a/R/export-method.R
+++ b/R/export-method.R
@@ -195,6 +195,7 @@ setMethod('.exportLoom', 'LoomGraphs',
 
     h5f <- H5Fopen(con) 
     tryCatch({
+        rhdf5::h5writeAttribute('2.0.1', h5obj=h5f, name='LOOM_SPEC_VERSION')
         rhdf5::h5writeAttribute(paste0('LoomExperiment-', as.character(
             packageVersion('LoomExperiment'))), name='CreatedWith', h5obj=h5f)
         rhdf5::h5writeAttribute(class(object), name='LoomExperiment-class',


### PR DESCRIPTION
Optional but very useful attribute (e.g. for sniffing the file type) specified in http://linnarssonlab.org/loompy/format/index.html?highlight=h5py#global-attributes